### PR TITLE
Revert "fix bugs changing core-site.xml owner and symlink loop"

### DIFF
--- a/security-admin/scripts/setup.sh
+++ b/security-admin/scripts/setup.sh
@@ -1413,17 +1413,13 @@ setup_install_files(){
 	fi
 	log "[I] Setting up installation files and directory DONE";
 
-	# Jack: Since the hadoop core-site.xml file is symlinked to the install directory,
-	#       the script will change ownership of the hadoop core-site.xml
-	#       to the unix_user and unix_group specified in the install.properties file. Not good!
-       #
-	#if [ ! -f ${INSTALL_DIR}/rpm ]; then
-	#    if [ -d ${INSTALL_DIR} ]
-	#    then
-	#	chown -R ${unix_user}:${unix_group} ${INSTALL_DIR}
-	#	chown -R ${unix_user}:${unix_group} ${INSTALL_DIR}/*
-	#    fi
-	#fi
+	if [ ! -f ${INSTALL_DIR}/rpm ]; then
+	    if [ -d ${INSTALL_DIR} ]
+	    then
+		chown -R ${unix_user}:${unix_group} ${INSTALL_DIR}
+		chown -R ${unix_user}:${unix_group} ${INSTALL_DIR}/*
+	    fi
+	fi
 
 	# Copy ranger-admin-services to /usr/bin
 	if [ ! \( -e /usr/bin/ranger-admin \) ]
@@ -1457,12 +1453,8 @@ else
 fi
 if [ "$?" == "0" ]
 then
-	echo "ln -sf ${WEBAPP_ROOT}/WEB-INF/classes/conf ${INSTALL_DIR}/conf (skipped)"
-	# Jack: Setup assumes ln -f will replace a symlink of a folder, when in fact it does not,
-	#       and instead creates the link to the folder one child below. Therefore, we get a symlink loop
-	#       when the link already exists.
-       #
-	# ln -sf ${WEBAPP_ROOT}/WEB-INF/classes/conf ${INSTALL_DIR}/conf
+	echo "ln -sf ${WEBAPP_ROOT}/WEB-INF/classes/conf ${INSTALL_DIR}/conf"
+	ln -sf ${WEBAPP_ROOT}/WEB-INF/classes/conf ${INSTALL_DIR}/conf
 else
 	exit 1
 fi


### PR DESCRIPTION
Temporary revert Altiscale/ranger#2 until we move away from HDFS user for Ranger Admin.

