### PR TITLE
Fix mvn build error

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/security/web/filter/AltiscaleRangerAuthFilter.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/web/filter/AltiscaleRangerAuthFilter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.ranger.security.web.filter;
 
 import org.apache.commons.collections.iterators.IteratorEnumeration;


### PR DESCRIPTION
Our maven build on jenkins is failing due to the lack of a license header. 