### PR TITLE
Fixing issue on usersync for portal users

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rest/UserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/UserREST.java
@@ -186,7 +186,7 @@ public class UserREST {
 	@Path("/default")
 	@Consumes({ "application/json", "application/xml" })
 	@Produces({ "application/xml", "application/json" })
-	@PreAuthorize("@rangerPreAuthSecurityHandler.isUGManagementAPIAccessible(\"" + RangerAPIList.CREATE_DEFAULT_ACCOUNT_USER + "\")")
+	@PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.CREATE_DEFAULT_ACCOUNT_USER + "\")")
 	public VXPortalUser createDefaultAccountUser(VXPortalUser userProfile,
 			@Context HttpServletRequest servletRequest) {
 		VXPortalUser vxPortalUser;

--- a/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
@@ -174,7 +174,7 @@ public class XUserREST {
 	@POST
 	@Path("/groups/groupinfo")
 	@Produces({ "application/xml", "application/json" })
-	@PreAuthorize("@rangerPreAuthSecurityHandler.isUGManagementAPIAccessible(\"" + RangerAPIList.CREATE_X_USER_GROUP_FROM_MAP + "\")")
+	@PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.CREATE_X_USER_GROUP_FROM_MAP + "\")")
 	public VXGroupUserInfo createXGroupUserFromMap(VXGroupUserInfo vXGroupUserInfo) {
 		return  xUserMgr.createXGroupUserFromMap(vXGroupUserInfo);
 	}
@@ -285,7 +285,7 @@ public class XUserREST {
 	@POST
 	@Path("/users/userinfo")
 	@Produces({ "application/xml", "application/json" })
-	@PreAuthorize("@rangerPreAuthSecurityHandler.isUGManagementAPIAccessible(\"" + RangerAPIList.CREATE_X_USER_GROUP_FROM_MAP + "\")")
+	@PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.CREATE_X_USER_GROUP_FROM_MAP + "\")")
 	public VXUserGroupInfo createXUserGroupFromMap(VXUserGroupInfo vXUserGroupInfo) {
 		return  xUserMgr.createXUserGroupFromMap(vXUserGroupInfo);
 	}
@@ -737,7 +737,7 @@ public class XUserREST {
 
 	@DELETE
 	@Path("/group/{groupName}/user/{userName}")
-	@PreAuthorize("@rangerPreAuthSecurityHandler.isUGManagementAPIAccessible(\"" + RangerAPIList.DELETE_X_GROUP_AND_X_USER + "\")")
+	@PreAuthorize("@rangerPreAuthSecurityHandler.isAPIAccessible(\"" + RangerAPIList.DELETE_X_GROUP_AND_X_USER + "\")")
 	public void deleteXGroupAndXUser(@PathParam("groupName") String groupName,
 			@PathParam("userName") String userName,
 			@Context HttpServletRequest request) {

--- a/ugsync/src/test/resources/ranger-ugsync-site.xml
+++ b/ugsync/src/test/resources/ranger-ugsync-site.xml
@@ -177,4 +177,8 @@
       <name>ranger.usersync.ldap.deltasync</name>
       <value>false</value>
     </property>
+    <property>
+        <name>ranger.usersync.admin.groups</name>
+        <value>admin</value>
+    </property>
   </configuration>


### PR DESCRIPTION
This PR fixes the following issues:
- The default rangerusersync user is able to sync users even if user/group management is disabled.
- The admins of portal, hive-plugin user, hdfs-pugin user are synced as ROLE_SYS_ADMIN for Ranger.