### PR TITLE
Use sysconfig for ranger-admin initd

### DIFF
--- a/embeddedwebserver/scripts/ranger-admin-initd
+++ b/embeddedwebserver/scripts/ranger-admin-initd
@@ -24,7 +24,8 @@
 # Short-Description: Start/Stop Ranger Admin
 ### END INIT INFO
 
-LINUX_USER=ranger
+. /etc/sysconfig/ranger-admin
+
 BIN_PATH=/usr/bin
 MOD_NAME=ranger-admin
 


### PR DESCRIPTION
- Use sysconfig to provide dynamic values for LINUX_USER and RANGER_USER during cluster deployment of Ranger