### PR TITLE
cherry pick from master that fixes jersey servlet error

### DIFF
--- a/kms/pom.xml
+++ b/kms/pom.xml
@@ -131,13 +131,13 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
-            <version>${sun-jersey-bundle.version}</version>
+            <version>${jersey-core.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>${sun-jersey-bundle.version}</version>
+            <version>${jersey-server.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-bundle</artifactId>
-            <version>${sun-jersey-bundle.version}</version>
+            <version>${jersey-bundle.version}</version>
         </dependency>
         <dependency>
             <groupId>asm</groupId>
@@ -336,7 +336,7 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-json</artifactId>
-            <version>${sun-jersey-bundle.version}</version>
+            <version>${jersey-bundle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,6 @@
         <springframework.test.version>3.2.18.RELEASE</springframework.test.version>
         <springframework.version>3.2.18.RELEASE</springframework.version>
         <storm.version>1.0.2</storm.version>
-        <tez.version>0.5.2</tez.version>
         <tomcat.embed.version>7.0.77</tomcat.embed.version>
         <velocity.version>1.7</velocity.version>
         <xmlenc.version>0.52</xmlenc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,9 +156,11 @@
         <jaxb-api.version>2.2.2</jaxb-api.version>
         <jaxb-impl.version>2.2.3-1</jaxb-impl.version>
         <jericho.html.version>3.3</jericho.html.version>
-        <jersey-bundle.version>1.17.1</jersey-bundle.version>
+        <jersey-bundle.version>1.19.3</jersey-bundle.version>
         <jersey-client.version>2.6</jersey-client.version>
-        <jersey-server.version>1.9</jersey-server.version>
+        <jersey-core.version>1.19.3</jersey-core.version>
+        <jersey-server.version>1.19.3</jersey-server.version>
+        <jersey-spring.version>1.19.3</jersey-spring.version>
         <jettison.version>1.1</jettison.version>
         <jline.version>0.9.94</jline.version>
         <joda-time.version>2.5</joda-time.version>
@@ -194,10 +196,7 @@
         <springframework.test.version>3.2.18.RELEASE</springframework.test.version>
         <springframework.version>3.2.18.RELEASE</springframework.version>
         <storm.version>1.0.2</storm.version>
-        <sun-jersey-bundle.version>1.19</sun-jersey-bundle.version>
-        <sun.jersey.bundle.version>1.4</sun.jersey.bundle.version>
-        <sun.jersey.core.version>1.4</sun.jersey.core.version>
-        <sun.jersey.spring.version>1.4</sun.jersey.spring.version>
+        <tez.version>0.5.2</tez.version>
         <tomcat.embed.version>7.0.77</tomcat.embed.version>
         <velocity.version>1.7</velocity.version>
         <xmlenc.version>0.52</xmlenc.version>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -210,12 +210,17 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-bundle</artifactId>
-            <version>${sun.jersey.bundle.version}</version>
+            <version>${jersey-bundle.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
-            <version>${sun.jersey.core.version}</version>
+            <version>${jersey-core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+            <version>${jettison.version}</version>
         </dependency>
         <dependency>
 			<groupId>org.apache.hadoop</groupId>
@@ -225,7 +230,7 @@
         <dependency>
             <groupId>com.sun.jersey.contribs</groupId>
             <artifactId>jersey-spring</artifactId>
-            <version>${sun.jersey.spring.version}</version>
+            <version>${jersey-spring.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -247,14 +252,22 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-context</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-aop</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
-	<dependency>
-		<groupId>com.sun.jersey.contribs</groupId>
-		<artifactId>jersey-multipart</artifactId>
-		<version>${sun.jersey.core.version}</version>
-	</dependency>
-    	<dependency>
+        <dependency>
+            <groupId>com.sun.jersey.contribs</groupId>
+            <artifactId>jersey-multipart</artifactId>
+            <version>${jersey-core.version}</version>
+        </dependency>
+        <dependency>
            <groupId>org.apache.solr</groupId>
            <artifactId>solr-solrj</artifactId>
           <version>${solr.version}</version>
@@ -390,12 +403,34 @@
                     <groupId>tomcat</groupId>
                     <artifactId>jasper-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>


### PR DESCRIPTION
@cetin-altiscale and I encountered a `java.lang.IncompatibleClassChangeError: Implementing class` being thrown during Servlet initialization after we upgraded other packages in the pom. 

This cherry pick from master resolved the initialization issue.