### PR TITLE
Include Audit Component in the Ranger Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     </mailingLists>
     <modules>
         <module>jisql</module>
+        <module>agents-audit</module>
         <module>agents-common</module>
         <module>agents-cred</module>
         <module>agents-installer</module>


### PR DESCRIPTION
Ranger HDFS and HIVE plugins require audit component (ranger-plugins-audit-0.7.1.jar) in the library path. This PR fixes this issue.