### PR TITLE
[BLUE-121] Hive2.x dependency downgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <hadoop.version>2.7.5</hadoop.version>
         <hamcrest.all.version>1.3</hamcrest.all.version>
         <hbase.version>1.2.4</hbase.version>
-        <hive.version>2.3.2</hive.version>
+        <hive.version>2.1.1</hive.version>
         <htrace-core.version>3.1.0-incubating</htrace-core.version>
 		<httpcomponents.httpclient.version>4.5.4</httpcomponents.httpclient.version>
 		<httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version>


### PR DESCRIPTION
Altiscale, as of now, provides Hive2.1.1. When Ranger depends on Hive2.3.2, the hiveserver2 autocomplete functionality was not working due to hive and hive-jdbc version mismatch. Therefore, this PR downgrades Hive2.x dependency to 2.1.1.

https://altiscale.atlassian.net/browse/BLUE-121 